### PR TITLE
Catch NumberFormatException when parsing versions

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/client/subsystem/sftp/impl/DefaultSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/client/subsystem/sftp/impl/DefaultSftpClient.java
@@ -444,8 +444,12 @@ public class DefaultSftpClient extends AbstractSftpClient {
             Collection<String> reported = (vers == null) ? null : vers.getVersions();
             if (GenericUtils.size(reported) > 0) {
                 for (String v : reported) {
-                    if (!available.add(Integer.valueOf(v))) {
-                        continue;   // debug breakpoint
+                    try {
+                        if (!available.add(Integer.valueOf(v))) {
+                            continue;   // debug breakpoint
+                        }
+                    } catch (NumberFormatException nfe) {
+                        log.debug("Could not parse reported version {}", v);
                     }
                 }
             }


### PR DESCRIPTION
This is necessary to be able to cope with the reported versions of SSH-2.0-VShell_4_2_1_1051 VShell:
"3,4,5,6,draft-ietf-secsh-filexfer-11@vandyke.com,partial-v6@vandyke.com"